### PR TITLE
Use Array.from() instead of spread syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,14 @@
     "node": ">=10"
   },
   "scripts": {
-    "build": "microbundle-crl --no-compress --format modern,cjs",
-    "start": "microbundle-crl watch --no-compress --format modern,cjs",
+    "build": "microbundle-crl --format modern,cjs",
+    "start": "microbundle-crl watch --format modern,cjs",
     "prepublish": "run-s build",
     "test": "run-s test:ci test:lint test:build",
     "test:build": "run-s build",
     "test:lint": "eslint .",
     "test:ci": "cross-env CI=1 react-scripts test -u --env=jsdom --coverage --watchAll=false",
     "test:unit": "react-scripts test --env=jsdom",
-    "test:watch": "react-scripts test --env=jsdom",
     "predeploy": "cd example && yarn install && yarn run build",
     "deploy": "gh-pages -d example/build"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "run-s test:ci test:lint test:build",
     "test:build": "run-s build",
     "test:lint": "eslint .",
-    "test:ci": "cross-env CI=1 react-scripts test -u --env=jsdom",
+    "test:ci": "cross-env CI=1 react-scripts test -u --env=jsdom --coverage --watchAll=false",
     "test:unit": "react-scripts test --env=jsdom",
     "test:watch": "react-scripts test --env=jsdom",
     "predeploy": "cd example && yarn install && yarn run build",
@@ -61,5 +61,24 @@
     "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
     "@types/sha.js": "^2.4.0",
     "sha.js": "^2.4.11"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "**/*.{js,jsx,ts,tsx}",
+      "!**/node_modules/**",
+      "!**/*.d.ts"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 90,
+        "functions": 90,
+        "lines": 90,
+        "statements": 90
+      }
+    },
+    "coverageReporters": [
+      "text-summary",
+      "html"
+    ]
   }
 }

--- a/src/__snapshots__/index.test.tsx.snap
+++ b/src/__snapshots__/index.test.tsx.snap
@@ -3,9 +3,341 @@
 exports[`Form renders with all the fields 1`] = `
 <div>
   <div>
+    <ul>
+      <li>
+        <strong>
+          MERCHANT_ID
+          :
+        </strong>
+        <br />
+        <code>
+           1
+        </code>
+      </li>
+      <li>
+        <strong>
+          ORDER_NUMBER
+          :
+        </strong>
+        <br />
+        <code>
+           1
+        </code>
+      </li>
+      <li>
+        <strong>
+          PARAMS_IN
+          :
+        </strong>
+        <br />
+        <code>
+           MERCHANT_ID,ORDER_NUMBER,PARAMS_IN,LOCALE,CURRENCY,REFERENCE_NUMBER,EXPIRATION_FOR_PAYMENT_CREATION,PAYMENT_METHODS,VAT_IS_INCLUDED,ALG,URL_SUCCESS,URL_CANCEL,URL_NOTIFY,ITEM_TITLE[0],ITEM_ID[0],ITEM_QUANTITY[0],ITEM_UNIT_PRICE[0],ITEM_VAT_PERCENT[0],ITEM_DISCOUNT_PERCENT[0],ITEM_TYPE[0],PAYER_PERSON_PHONE,PAYER_PERSON_EMAIL,PAYER_PERSON_FIRSTNAME,PAYER_PERSON_LASTNAME,PAYER_COMPANY_NAME,PAYER_PERSON_ADDR_STREET,PAYER_PERSON_ADDR_POSTAL_CODE,PAYER_PERSON_ADDR_TOWN,PAYER_PERSON_ADDR_COUNTRY,MSG_UI_MERCHANT_PANEL,MSG_SETTLEMENT_PAYER,MSG_UI_PAYMENT_METHOD,PARAMS_OUT
+        </code>
+      </li>
+      <li>
+        <strong>
+          LOCALE
+          :
+        </strong>
+        <br />
+        <code>
+           fi_FI
+        </code>
+      </li>
+      <li>
+        <strong>
+          CURRENCY
+          :
+        </strong>
+        <br />
+        <code>
+           EUR
+        </code>
+      </li>
+      <li>
+        <strong>
+          REFERENCE_NUMBER
+          :
+        </strong>
+        <br />
+        <code>
+           RF123456789
+        </code>
+      </li>
+      <li>
+        <strong>
+          EXPIRATION_FOR_PAYMENT_CREATION
+          :
+        </strong>
+        <br />
+        <code>
+           2021-01-01
+        </code>
+      </li>
+      <li>
+        <strong>
+          PAYMENT_METHODS
+          :
+        </strong>
+        <br />
+        <code>
+           1,2
+        </code>
+      </li>
+      <li>
+        <strong>
+          VAT_IS_INCLUDED
+          :
+        </strong>
+        <br />
+        <code>
+           0
+        </code>
+      </li>
+      <li>
+        <strong>
+          ALG
+          :
+        </strong>
+        <br />
+        <code>
+           1
+        </code>
+      </li>
+      <li>
+        <strong>
+          URL_SUCCESS
+          :
+        </strong>
+        <br />
+        <code>
+           https://example.com/success
+        </code>
+      </li>
+      <li>
+        <strong>
+          URL_CANCEL
+          :
+        </strong>
+        <br />
+        <code>
+           https://example.com/cancel
+        </code>
+      </li>
+      <li>
+        <strong>
+          URL_NOTIFY
+          :
+        </strong>
+        <br />
+        <code>
+           https://example.com/notify
+        </code>
+      </li>
+      <li>
+        <strong>
+          ITEM_TITLE[0]
+          :
+        </strong>
+        <br />
+        <code>
+           Test Product
+        </code>
+      </li>
+      <li>
+        <strong>
+          ITEM_ID[0]
+          :
+        </strong>
+        <br />
+        <code>
+           123
+        </code>
+      </li>
+      <li>
+        <strong>
+          ITEM_QUANTITY[0]
+          :
+        </strong>
+        <br />
+        <code>
+           1
+        </code>
+      </li>
+      <li>
+        <strong>
+          ITEM_UNIT_PRICE[0]
+          :
+        </strong>
+        <br />
+        <code>
+           100.00
+        </code>
+      </li>
+      <li>
+        <strong>
+          ITEM_VAT_PERCENT[0]
+          :
+        </strong>
+        <br />
+        <code>
+           24
+        </code>
+      </li>
+      <li>
+        <strong>
+          ITEM_DISCOUNT_PERCENT[0]
+          :
+        </strong>
+        <br />
+        <code>
+           10
+        </code>
+      </li>
+      <li>
+        <strong>
+          ITEM_TYPE[0]
+          :
+        </strong>
+        <br />
+        <code>
+           1
+        </code>
+      </li>
+      <li>
+        <strong>
+          PAYER_PERSON_PHONE
+          :
+        </strong>
+        <br />
+        <code>
+           040123456
+        </code>
+      </li>
+      <li>
+        <strong>
+          PAYER_PERSON_EMAIL
+          :
+        </strong>
+        <br />
+        <code>
+           alice@example.org
+        </code>
+      </li>
+      <li>
+        <strong>
+          PAYER_PERSON_FIRSTNAME
+          :
+        </strong>
+        <br />
+        <code>
+           Alice
+        </code>
+      </li>
+      <li>
+        <strong>
+          PAYER_PERSON_LASTNAME
+          :
+        </strong>
+        <br />
+        <code>
+           Angel
+        </code>
+      </li>
+      <li>
+        <strong>
+          PAYER_COMPANY_NAME
+          :
+        </strong>
+        <br />
+        <code>
+           Acme Ltd
+        </code>
+      </li>
+      <li>
+        <strong>
+          PAYER_PERSON_ADDR_STREET
+          :
+        </strong>
+        <br />
+        <code>
+           Test Street 1
+        </code>
+      </li>
+      <li>
+        <strong>
+          PAYER_PERSON_ADDR_POSTAL_CODE
+          :
+        </strong>
+        <br />
+        <code>
+           00100
+        </code>
+      </li>
+      <li>
+        <strong>
+          PAYER_PERSON_ADDR_TOWN
+          :
+        </strong>
+        <br />
+        <code>
+           Helsinki
+        </code>
+      </li>
+      <li>
+        <strong>
+          PAYER_PERSON_ADDR_COUNTRY
+          :
+        </strong>
+        <br />
+        <code>
+           FI
+        </code>
+      </li>
+      <li>
+        <strong>
+          MSG_UI_MERCHANT_PANEL
+          :
+        </strong>
+        <br />
+        <code>
+           This is a message for the Merchant's Panel
+        </code>
+      </li>
+      <li>
+        <strong>
+          MSG_SETTLEMENT_PAYER
+          :
+        </strong>
+        <br />
+        <code>
+           This is a message for the customer
+        </code>
+      </li>
+      <li>
+        <strong>
+          MSG_UI_PAYMENT_METHOD
+          :
+        </strong>
+        <br />
+        <code>
+           This is a message for the payment method
+        </code>
+      </li>
+      <li>
+        <strong>
+          PARAMS_OUT
+          :
+        </strong>
+        <br />
+        <code>
+           ORDER_NUMBER,PAYMENT_ID,AMOUNT,CURRENCY,PAYMENT_METHOD,TIMESTAMP,STATUS
+        </code>
+      </li>
+    </ul>
     <form
       action="https://payment.paytrail.com/e2"
-      class="e2-form"
+      class="e2-test-form"
       method="post"
     >
       <input
@@ -51,7 +383,7 @@ exports[`Form renders with all the fields 1`] = `
       <input
         name="VAT_IS_INCLUDED"
         type="hidden"
-        value="1"
+        value="0"
       />
       <input
         name="ALG"
@@ -176,7 +508,7 @@ exports[`Form renders with all the fields 1`] = `
       <input
         name="AUTHCODE"
         type="hidden"
-        value="24442E884055706A8954DB39EEE246EBD01C92CB4205A1A18CD88A32887389A6"
+        value="CA8A6BCB3A31EEB4114A6DE1A5DE8D48F7D33D3E0C081310E63CAB5A8E9E4CA1"
       />
       <button
         type="submit"

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -84,7 +84,7 @@ class FieldMap extends Map {
     const outParameters = ['ORDER_NUMBER', 'PAYMENT_ID', 'AMOUNT', 'CURRENCY', 'PAYMENT_METHOD', 'TIMESTAMP', 'STATUS']
     this.add('PARAMS_OUT', outParameters.join(','))
 
-    const inParameters = [...this.keys()]
+    const inParameters = Array.from(this.keys())
     return this.add('PARAMS_IN', inParameters.join(','))
   }
 
@@ -96,7 +96,7 @@ class FieldMap extends Map {
    * @returns AUTHCODE converted to uppercase.
    */
   authCode(secret: string, algorithm: string): string {
-    const values = [secret, ...this.values()].join('|')
+    const values = [secret].concat(Array.from(this.values())).join('|')
 
     return shajs(algorithm).update(values).digest('hex').toUpperCase()
   }

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -47,13 +47,14 @@ test('Form renders with all the fields', async () => {
     secret: '123',
   }
 
+  const className = 'e2-test-form'
   const orderNumber = '1'
   const paymentMethods = [1, 2]
   const reference = 'RF123456789'
   const currency = 'EUR'
   const locale = 'fi_FI'
   const algorithm = 'sha256'
-  const includeVat = true
+  const includeVat = false
 
   const expiresAt = '2021-01-01'
   const urls = getURLs('https://example.com')
@@ -90,6 +91,8 @@ test('Form renders with all the fields', async () => {
 
   const { container } = render(
     <Form
+      className={className}
+      debug
       merchant={merchant}
       orderNumber={orderNumber}
       urls={urls}
@@ -106,15 +109,19 @@ test('Form renders with all the fields', async () => {
     />,
   )
 
+  const expectedInputFields = 34
+  const expectedDebugFields = expectedInputFields - 1 // AUTHCODE is not shown in debug
+
   expect(container).toMatchSnapshot()
-  expect(container.querySelectorAll('input')).toHaveLength(34)
+  expect(container.querySelectorAll('input')).toHaveLength(expectedInputFields)
+  expect(container.querySelectorAll('ul > li')).toHaveLength(expectedDebugFields)
   expect(container.querySelector('input[name=MERCHANT_ID')).toHaveProperty('value', merchant.id)
   expect(container.querySelector('input[name=ORDER_NUMBER')).toHaveProperty('value', orderNumber)
   expect(container.querySelector('input[name=PAYMENT_METHODS')).toHaveProperty('value', '1,2')
   expect(container.querySelector('input[name=REFERENCE_NUMBER')).toHaveProperty('value', reference)
   expect(container.querySelector('input[name=CURRENCY')).toHaveProperty('value', currency)
   expect(container.querySelector('input[name=LOCALE')).toHaveProperty('value', locale)
-  expect(container.querySelector('input[name=VAT_IS_INCLUDED')).toHaveProperty('value', '1')
+  expect(container.querySelector('input[name=VAT_IS_INCLUDED')).toHaveProperty('value', '0')
   expect(container.querySelector('input[name=EXPIRATION_FOR_PAYMENT_CREATION')).toHaveProperty('value', expiresAt)
   expect(container.querySelector('input[name=URL_SUCCESS')).toHaveProperty('value', urls.success.href)
   expect(container.querySelector('input[name=URL_CANCEL')).toHaveProperty('value', urls.cancel.href)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,7 @@ export const Form: React.FC<FormProps> = props => {
     algorithm = 'sha256',
     expiresAt = '',
     debug = false,
-    className = 'e2-form'
+    className = 'e2-form',
   } = props
 
   const gateway = 'https://payment.paytrail.com/e2'
@@ -66,7 +66,7 @@ export const Form: React.FC<FormProps> = props => {
     .addMessages(messages)
     .addParams()
 
-  const fieldEntries = [...fields.entries()]
+  const fieldEntries = Array.from(fields.entries())
 
   return (
     <div>

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -33,7 +33,6 @@ interface DebugProps {
 }
 
 interface FormProps {
-  className: string
   merchant: Merchant
   orderNumber: string
   urls: URLSet
@@ -48,6 +47,7 @@ interface FormProps {
   algorithm?: 'sha256'
   messages?: MessageSet
   expiresAt?: string
+  className?: string
 }
 
 interface Merchant {


### PR DESCRIPTION
## What type of Pull Request is this?

Check all the applicable.

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This makes the production build and applications using this library functional again. The issue was likely in how Webpack (and other bundlers) would handle the `[...array]` notation during compiling. It resulted in an iterator object instead of an array which was exhausted too quickly. Hence, the React component could not render any fields.

Test this by building the example application and verify that all the `<input>` fields are filled.

Jest now calculates code coverage when running unit tests. Minimum coverage is **90 %** which may be changed later if necessary. Some of the test cases were improved to satisfy the new coverage limits, hence the new snapshot.

Turned out that `className` prop for the `<Form>` component was typed as required which was not the case so it has been typed as optional now.

## Tests

- [ ] Not needed
- [x] Unit tests added
- [ ] Integration tests added
- [ ] Visual verification done

## Related Tickets & Documents

Fixes #21

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
